### PR TITLE
Refactor entire code base to capture linter output using JSON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 language: python
 python:
-  - "3.3"
-# command to install dependencies
+  - "3.6"
 install:
   - pip install flake8
-  - pip install pep257
-# command to run tests
 script:
-  - flake8 *.py --max-line-length=120
-  - pep257 . --ignore=D202
+  - flake8 . --max-line-length=120

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Copyright (c) 2018 Alec Thomas
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+install:
+	zip -r9v "$${HOME}/Library/Application Support/Sublime Text 3/Installed Packages/SublimeLinter-golangcilint.sublime-package" .

--- a/README.md
+++ b/README.md
@@ -4,21 +4,34 @@ This linter plugin for [SublimeLinter][docs] provides an interface to [golangci-
 
 ## Installation
 
-SublimeLinter 3 must be installed in order to use this plugin.
+- Install SublimeLinter 3 from [here](https://packagecontrol.io/packages/SublimeLinter)
+- Install SublimeLinter-golangcilint from [here](https://packagecontrol.io/packages/SublimeLinter-contrib-golang-cilint)
+- Install the `golangci-lint` helper from [here](https://github.com/golangci/golangci-lint#install)
 
-If SublimeLinter 3 is not installed, please follow the instructions [here][installation].
-
-### Linter installation
-
-Before using this plugin, you must ensure that `golangci-lint` is installed on your system.
-
-Please refer to the official [installation instructions](https://github.com/golangci/golangci-lint#install).
-
-### Linter configuration
+## Configuration
 
 In order for `golangci-lint` to be executed by SublimeLinter, you must ensure that its path is available to SublimeLinter. Before going any further, please read and follow the steps in [“Finding a linter executable”](http://sublimelinter.readthedocs.org/en/latest/troubleshooting.html#finding-a-linter-executable) through “Validating your PATH” in the documentation. Once you have installed `golangci-lint`, you can proceed to install the SublimeLinter-contrib-golangci-lint plugin if it is not yet installed.
 
-### Plugin installation
+**Note:** The linter creates a temporary directory to allow SublimeLinter to scan changes in the code that are still in the buffer _(aka. not saved yet)_. If the SublimeText sidebar is visible, you will notice _—for a split of a second—_ that a folder named `.golangcilint-*` appears and disappears. Make sure to add this folder to your `.gitignore` file, and also the “folder_exclude_patterns” in SublimeText’s preferences:
+
+```
+{
+    "folder_exclude_patterns":
+    [
+        ".svn",
+        ".git",
+        ".hg",
+        "CVS",
+        "cache",
+        "uploads",
+        ".golangci-*",
+        ".golangcilint-*",
+        ".gometalinter-*"
+    ],
+}
+```
+
+## Plugin installation
 
 Please use [Package Control][pc] to install the linter plugin. This will ensure that the plugin will be updated when new versions are available. If you want to install from source so you can modify the source code, you probably know what you are doing so we won’t cover that here.
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,22 @@
-SublimeLinter-contrib-golangci-lint
-================================
+# SublimeLinter-contrib-golangci-lint
 
-This linter plugin for [SublimeLinter][docs] provides an interface to [golangci-lint](https://github.com/golangci/golangci-lint). It will be used with files that have the “Go” syntax.
+This linter plugin for [SublimeLinter][docs] provides an interface to [golangci-lint](https://github.com/golangci/golangci-lint), a linter for Go (golang).
 
 ## Installation
-SublimeLinter 3 must be installed in order to use this plugin. If SublimeLinter 3 is not installed, please follow the instructions [here][installation].
+
+SublimeLinter 3 must be installed in order to use this plugin.
+
+If SublimeLinter 3 is not installed, please follow the instructions [here][installation].
 
 ### Linter installation
-Before using this plugin, you must ensure that `golangci-lint` is installed on your system. To install `golangci-lint`, do the following:
 
-1. Install [Go](http://golang.org/doc/install).
+Before using this plugin, you must ensure that `golangci-lint` is installed on your system.
 
-1. Install `golangci-lint` by typing the following in a terminal:
-   ```
-   go get github.com/golangci/golangci-lint/cmd/golangci-lint
-   ```
+Please refer to the official [installation instructions](https://github.com/golangci/golangci-lint#install).
 
 ### Linter configuration
-In order for `golangci-lint` to be executed by SublimeLinter, you must ensure that its path is available to SublimeLinter. Before going any further, please read and follow the steps in [“Finding a linter executable”](http://sublimelinter.readthedocs.org/en/latest/troubleshooting.html#finding-a-linter-executable) through “Validating your PATH” in the documentation.
 
-Once you have installed `golangci-lint`, you can proceed to install the SublimeLinter-contrib-golangci-lint plugin if it is not yet installed.
+In order for `golangci-lint` to be executed by SublimeLinter, you must ensure that its path is available to SublimeLinter. Before going any further, please read and follow the steps in [“Finding a linter executable”](http://sublimelinter.readthedocs.org/en/latest/troubleshooting.html#finding-a-linter-executable) through “Validating your PATH” in the documentation. Once you have installed `golangci-lint`, you can proceed to install the SublimeLinter-contrib-golangci-lint plugin if it is not yet installed.
 
 ### Plugin installation
 
@@ -28,7 +25,6 @@ Please use [Package Control][pc] to install the linter plugin. This will ensure 
 To install via Package Control, do the following:
 
 1. Within Sublime Text, bring up the [Command Palette][cmd] and type `install`. Among the commands you should see `Package Control: Install Package`. If that command is not highlighted, use the keyboard or mouse to select it. There will be a pause of a few seconds while Package Control fetches the list of available plugins.
-
 1. When the plugin list appears, type `golangci-lint`. Among the entries you should see `SublimeLinter-contrib-golangci-lint`. If that entry is not highlighted, use the keyboard or mouse to select it.
 
 ## Usage

--- a/linter.py
+++ b/linter.py
@@ -3,86 +3,120 @@
 # Linter for SublimeLinter3, a code checking framework for Sublime Text 3
 #
 # Written by Alec Thomas
-# Copyright (c) 2014 Alec Thomas
+# Copyright (c) 2018 Alec Thomas
 #
 # License: MIT
 #
 
-"""This module exports the Gometalinter plugin class."""
+"""This module exports the Golangcilint plugin class."""
 
 import os
-import shlex
+import json
 import tempfile
-
-from SublimeLinter.lint import Linter, highlight, util
+from SublimeLinter.lint import Linter, util
 from SublimeLinter.lint.persist import settings
 
 
-class GolangCILint(Linter):
-    """Provides an interface to golangci-lint."""
-
-    syntax = ('go', 'gosublime-go', 'gotools', 'anacondago-go')
-    cmd = 'golangci-lint run --fast --enable typecheck'
-    regex = r'(?:[^:]+):(?P<line>\d+):(?P<col>\d+)?:\s*(?P<message>.*)'
-    error_stream = util.STREAM_BOTH
-    default_type = highlight.ERROR
+class Golangcilint(Linter):
+    cmd = "golangci-lint run --fast --out-format json --enable typecheck"
+    regex = r"(?:[^:]+):(?P<line>\d+):(?P<col>\d+):(?:(?P<warning>warning)|(?P<error>error)):(?P<message>.*)"
+    defaults = {"selector": "source.go"}
+    error_stream = util.STREAM_STDOUT
+    multiline = False
 
     def run(self, cmd, code):
-        filename = os.path.basename(self.filename)
-        if settings.get('lint_mode') == 'background':
-            out = self._live_lint(cmd, code)
-        else:
-            out = self._in_place_lint(cmd)
-        lines = [line for line in out.splitlines()
-                 if line.startswith(filename + ':')]
-        return '\n'.join(lines)
-
-    def _dir_env(self):
-        settings = self.get_view_settings()
         dir = os.path.dirname(self.filename)
-        env = self.get_environment(settings)
-        return dir, env
+        if not dir:
+            print("golangcilint: skipped linting of unsaved file")
+            return
+        if settings.get("lint_mode") == "background":
+            return self._live_lint(cmd, code)
+        else:
+            return self._in_place_lint(cmd)
+
+    def finalize_cmd(self, cmd, context, at_value='', auto_append=False):
+        """prevents SublimeLinter to append filename at the end of cmd"""
+        return cmd
 
     def _live_lint(self, cmd, code):
-        dir, env = self._dir_env()
-        if not dir:
-            print('golangci-lint: skipped linting of unsaved file')
-            return
-        filename = os.path.basename(self.filename)
-        print('golangci-lint: live linting {} in {}: {}'.format(filename, dir, ' '.join(map(shlex.quote, cmd))))
-        files = [f for f in os.listdir(dir) if f.endswith('.go')]
-        if len(files) > 40:
-            print("golangci-lint: too many files ({}), live linting skipped".format(len(files)))
-            return ''
-        return tmpdir(cmd, dir, files, self.filename, code, env=env)
+        dir = os.path.dirname(self.filename)
+        files = [file for file in os.listdir(dir) if file.endswith(".go")]
+        if len(files) > 100:
+            print("golangcilint: too many files ({}), live linting skipped".format(len(files)))
+            return ""
+        return self.tmpdir(cmd, dir, files, self.filename, code)
 
     def _in_place_lint(self, cmd):
-        dir, env = self._dir_env()
-        if not dir:
-            print('golangci-lint: skipped linting of unsaved file')
-            return
-        filename = os.path.basename(self.filename)
-        print('golangci-lint: in-place linting {}: {}'.format(filename, ' '.join(map(shlex.quote, cmd))))
-        out = util.communicate(cmd, output_stream=util.STREAM_BOTH, env=env, cwd=dir)
-        return out or ''
+        return self.execute(cmd)
 
+    def tmpdir(self, cmd, dir, files, filename, code):
+        """Run an external executable using a temp dir filled with files and return its output."""
+        try:
+            with tempfile.TemporaryDirectory(dir=dir, prefix=".golangcilint-") as tmpdir:
+                for filepath in files:
+                    target = os.path.join(tmpdir, filepath)
+                    filepath = os.path.join(dir, filepath)
+                    if os.path.basename(target) != os.path.basename(filename):
+                        os.link(filepath, target)
+                        continue
+                    # source file hasn't been saved since change
+                    # so update it from our live buffer for now
+                    with open(target, 'wb') as w:
+                        if isinstance(code, str):
+                            code = code.encode('utf8')
+                        w.write(code)
+                return self.execute(cmd + [tmpdir])
+        except FileNotFoundError:
+            print("golangcilint file not found error on `{}`".format(dir))
+            return ""
+        except PermissionError:
+            print("golangcilint permission error on `{}`".format(dir))
+            return ""
 
-def tmpdir(cmd, dir, files, filename, code, env=None):
-    """Run an external executable using a temp dir filled with files and return its output."""
-    with tempfile.TemporaryDirectory(dir=dir, prefix=".golangci-lint-") as tmpdir:
-        for f in files:
-            target = os.path.join(tmpdir, f)
-            f = os.path.join(dir, f)
+    def issue_level(self, issue):
+        return "error" if issue["FromLinter"] == "typecheck" else "warning"
 
-            if os.path.basename(target) == os.path.basename(filename):
-                # source file hasn't been saved since change, so update it from our live buffer
-                with open(target, 'wb') as f:
-                    if isinstance(code, str):
-                        code = code.encode('utf8')
+    def execute(self, cmd):
+        lines = []
+        output = self.communicate(cmd)
+        report = json.loads(output)
+        currnt = os.path.basename(self.filename)
 
-                    f.write(code)
-            else:
-                os.link(f, target)
+        """merge possible stderr with issues"""
+        if "Error" in report["Report"]:
+            for line in report["Report"]["Error"].splitlines():
+                if line.count(":") < 3:
+                    continue
+                parts = line.split(":")
+                report["Issues"].append({
+                    "FromLinter": "typecheck",
+                    "Text": parts[3].strip(),
+                    "Pos": {
+                        "Filename": parts[0],
+                        "Line": parts[1],
+                        "Column": parts[2],
+                    }
+                })
 
-        out = util.communicate(cmd, output_stream=util.STREAM_BOTH, env=env, cwd=tmpdir)
-    return out or ''
+        """format issues into formal pattern"""
+        for issue in report["Issues"]:
+            name = issue["Pos"]["Filename"]
+            mark = name.rfind("/")
+            mark = 0 if mark == -1 else mark+1
+            issue["Pos"]["Shortname"] = name[mark:]
+            """decide if it is a warning or error"""
+            issue["Level"] = self.issue_level(issue)
+            """skip issues from unrelated files"""
+            if issue["Pos"]["Shortname"] != currnt:
+                continue
+            lines.append(
+                "{}:{}:{}:{}:{}".format(
+                    issue["Pos"]["Shortname"],
+                    issue["Pos"]["Line"],
+                    issue["Pos"]["Column"],
+                    issue["Level"],
+                    issue["Text"]
+                )
+            )
+
+        return "\n".join(lines)

--- a/linter.py
+++ b/linter.py
@@ -74,6 +74,7 @@ class Golangcilint(Linter):
             return ""
 
     def issue_level(self, issue):
+        """consider /dev/stderr as errors and /dev/stdout as warnings"""
         return "error" if issue["FromLinter"] == "typecheck" else "warning"
 
     def execute(self, cmd):

--- a/messages/install.txt
+++ b/messages/install.txt
@@ -1,10 +1,10 @@
-SublimeLinter-contrib-gometalinter
+SublimeLinter-contrib-golang-cilint
 -------------------------------
-This linter plugin for SublimeLinter provides an interface to gometalinter.
+This linter plugin for SublimeLinter provides an interface to golangci-lint.
 
 ** IMPORTANT! **
 
 Before this plugin will activate, you *must*
 follow the installation instructions here:
 
-https://github.com/alecthomas/SublimeLinter-contrib-gometalinter
+https://github.com/alecthomas/SublimeLinter-contrib-golang-cilint


### PR DESCRIPTION
Older versions of `golangci-lint` were sending output exclusively to `/dev/stdout` and using a more standard format. However, the latest version either has a bug or is changing from its original design, because there are errors and warnings in `/dev/stderr` too which differ from the other messages just by a few characters, for example, missing a colon after the column number. I’ve fixed these problems and improved the parser by leveraging the JSON output, and formalizing both `/dev/stderr` as Errors and `/dev/stdout` as warnings.

I also went ahead and submitted the project to SublimeLinter repository for inclusion in their registry to allow people to install the linter via Package Control [1]. I immediately approached the original author to ask for a review and hopefully merge the fixes so others can benefit from the improvements.

[1] https://github.com/SublimeLinter/package_control_channel/pull/83